### PR TITLE
Add comparator for edges

### DIFF
--- a/src/main/kotlin/EdgeWeightComparator.kt
+++ b/src/main/kotlin/EdgeWeightComparator.kt
@@ -1,0 +1,8 @@
+package graph
+
+/**
+ * Comparator for [Edge]s based on their weight.
+ */
+object EdgeWeightComparator : Comparator<Edge> {
+    override fun compare(o1: Edge, o2: Edge): Int = o1.weight.compareTo(o2.weight)
+}

--- a/src/test/kotlin/EdgeComparatorTest.kt
+++ b/src/test/kotlin/EdgeComparatorTest.kt
@@ -1,0 +1,13 @@
+package graph
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class EdgeComparatorTest {
+    @Test
+    fun `compare edges by weight`() {
+        val e1 = Edge.Viewed(Node.Item("i1"))
+        val e2 = Edge.Bought(Node.Item("i2"))
+        assertTrue(EdgeWeightComparator.compare(e1, e2) < 0)
+    }
+}


### PR DESCRIPTION
## Summary
- implement a comparator for edges that compares their weight
- test weight-based comparator for edges

## Testing
- `./gradlew test --no-daemon`

------
https://chatgpt.com/codex/tasks/task_e_6886925d9a20832d95cf633a3411fbf8