### PR TITLE
Implement timestamp decay for edge subclasses

### DIFF
--- a/src/main/kotlin/Graph.kt
+++ b/src/main/kotlin/Graph.kt
@@ -1,15 +1,46 @@
 package graph
 
 import java.io.Serializable
+import java.time.Duration
+import java.time.Instant
+import kotlin.math.exp
+import kotlin.math.ln
 
 sealed class Node(open val id: String, val type: String) : Serializable {
     data class User(override val id: String) : Node(id, "User")
     data class Item(override val id: String) : Node(id, "Item")
 }
 
-sealed class Edge(open val to: Node, val type: String, val weight: Double) : Serializable {
-    data class Viewed(override val to: Node) : Edge(to, "Viewed", 0.1)
-    data class Bought(override val to: Node) : Edge(to, "Bought", 0.4)
+sealed class Edge(
+    open val to: Node,
+    val type: String
+) : Serializable {
+
+    /** Weight of the edge. */
+    abstract val weight: Double
+
+    data class Viewed(override val to: Node, val timestamp: Instant = Instant.now()) :
+        Edge(to, "Viewed") {
+        override val weight: Double
+            get() {
+                val days = Duration.between(timestamp, Instant.now()).toDays().toDouble()
+                return (0.1 - TERMINAL_WEIGHT) * exp(-DECAY_K * days)
+            }
+    }
+
+    data class Bought(override val to: Node, val timestamp: Instant = Instant.now()) :
+        Edge(to, "Bought") {
+        override val weight: Double
+            get() {
+                val days = Duration.between(timestamp, Instant.now()).toDays().toDouble()
+                return (0.4 - TERMINAL_WEIGHT) * exp(-DECAY_K * days)
+            }
+    }
+
+    companion object {
+        private const val TERMINAL_WEIGHT = 0.0
+        private val DECAY_K: Double = ln(100.0) / 30.0
+    }
 }
 
 interface Graph {

--- a/src/test/kotlin/GraphTest.kt
+++ b/src/test/kotlin/GraphTest.kt
@@ -25,11 +25,11 @@ class GraphTest {
         graph.addEdge(user, Edge.Viewed(item))
         graph.addEdge(user, Edge.Bought(item))
 
-        val edges = graph.getEdges(user).toList()
+        val edges = graph.getEdges(user).sortedBy { it.type }
         assertEquals(2, edges.size)
-        assertEquals("Viewed", edges[0].type)
-        assertEquals(0.1, edges[0].weight)
-        assertEquals("Bought", edges[1].type)
-        assertEquals(0.4, edges[1].weight)
+        assertEquals("Bought", edges[0].type)
+        assertEquals(0.4, edges[0].weight)
+        assertEquals("Viewed", edges[1].type)
+        assertEquals(0.1, edges[1].weight)
     }
 }


### PR DESCRIPTION
## Summary
- compute decaying weights in `Edge.Viewed` and `Edge.Bought`
- keep base `Edge` free of timestamp

## Testing
- `gradle test --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_688693d7c2c8832d8f3902d6fbebbe7a